### PR TITLE
Added support for reading ~/.aws/config

### DIFF
--- a/parameterstore/parameterstore.go
+++ b/parameterstore/parameterstore.go
@@ -26,7 +26,9 @@ type ParameterStore struct {
 
 // NewParameterStore initializes a ParameterStore with default values
 func (ps *ParameterStore) NewParameterStore() error {
-	sess := session.Must(session.NewSession())
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 	ps.Confirm = false
 	ps.Cwd = Delimiter
 	ps.Decrypt = false


### PR DESCRIPTION
The default SDK only loads the shared credentials file
`~/.aws/credentials`, credentials values, etc.

Adding the SharedConfigEnable option will create the session and also
load the configuration in `/~.aws/config`.